### PR TITLE
Fix error with ignore 404 in Delete bill run

### DIFF
--- a/tests.jmx
+++ b/tests.jmx
@@ -1176,12 +1176,12 @@ without actual network activity. This helps debugging tests.</stringProp>
               <hashTree/>
               <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Ignore 404" enabled="true">
                 <collectionProp name="Asserion.test_strings">
-                  <stringProp name="51512">404</stringProp>
+                  <stringProp name="-1447182354">200|404</stringProp>
                 </collectionProp>
                 <stringProp name="Assertion.custom_message"></stringProp>
                 <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
                 <boolProp name="Assertion.assume_success">true</boolProp>
-                <intProp name="Assertion.test_type">8</intProp>
+                <intProp name="Assertion.test_type">2</intProp>
               </ResponseAssertion>
               <hashTree/>
             </hashTree>


### PR DESCRIPTION
We added a condition that meant the `404` returned when the bill run status `GET` call is used is not seen by JMeter as an error. What we weren't able to confirm at the time is if it returns a `200` would it still work (it doesn't!) We just didn't have enough data to cause the delete process to take long enough for polling to be needed.

This change fixes the issue by updating the condition in the [JMeter response assetion](https://jmeter.apache.org/usermanual/component_reference.html#Response_Assertion) to check for both `200` or `404`.