### PR TITLE
Better support running tests using JMeter CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ chromedriver.log
 /.byebug_history
 *.log
 
+# JMeter test output. Created when running JMeter in CLI mode using cli.sh.
+# Note: each time cli.sh is run it will delete the existing .jtl file for the specified test first
+*.jtl
+
 # Dotenv https://github.com/motdotla/dotenv
 # Ignore our .env files as they contain actual credentials. The .example.env file gets committed to act as documentation
 # on what environment variables need to be set up

--- a/README.md
+++ b/README.md
@@ -39,23 +39,64 @@ Git is setup to ignore everything bar the example environment file. Even so, dou
 
 ## Execution
 
-The project is currently setup to run JMeter in GUI mode. Tests can be created, edited and run from the GUI though it's recommended to use [CLI mode](https://jmeter.apache.org/usermanual/best-practices.html#lean_mean) when running the tests for real.
+Test plans can be run in either [GUI](https://jmeter.apache.org/usermanual/get-started.html#running) or [CLI](https://jmeter.apache.org/usermanual/get-started.html#non_gui) mode.
+
+Use GUI mode to create, edit and and debug tests. It's [recommended](https://jmeter.apache.org/usermanual/best-practices.html#lean_mean) to use CLI mode when running the tests for real.
+
+### GUI Mode
 
 From the root of the project in a terminal run
 
 ```bash
-./run.sh test tests.jmx
+./gui.sh test tests.jmx
 ```
 
 The first arg is required and is the name of the environment to use and should match the name of a config file in `environments/`. For example
 
 ```bash
-./run.sh dev tests.jmx # environments/.dev.env
-./run.sh local tests.jmx # environments/.local.env
-./run.sh test tests.jmx # environments/.test.env
+./gui.sh dev tests.jmx # environments/.dev.env
+./gui.sh local tests.jmx # environments/.local.env
+./gui.sh test tests.jmx # environments/.test.env
 ```
 
 The second arg is the JMeter `.jmx` file to load. This is not required and if left blank JMeter will start in its default state ready to create a new `.jmx` file. Everything from the environment config will still be available though, loaded as environment variables in the current session.
+
+### CLI mode
+
+From the root of the project in a terminal run
+
+```bash
+./gui.sh test tests.jmx
+```
+
+The first arg is required and is the name of the environment to use and should match the name of a config file in `environments/`. For example
+
+```bash
+./gui.sh dev tests.jmx # environments/.dev.env
+./gui.sh local tests.jmx # environments/.local.env
+./gui.sh test tests.jmx # environments/.test.env
+```
+
+The second arg is the JMeter `.jmx` file to load. This is not required and if left the script will default to using `tests.jmx`.
+
+When run in this way no GUI will appear and test output will be written to a [.jtl file](https://jmeter.apache.org/usermanual/listeners.html#batch).
+
+## Enabling/Disabling tests
+
+JMeter stores test plans in `.jmx` files. Our main test plan `tests.jmx` features multiple scenarios to be tested. These are held under [Thread Groups](https://jmeter.apache.org/usermanual/test_plan.html#thread_group).
+
+From the GUI you can disable and enable these thread groups (scenarios). But this information is saved to the jmx file. This can be a problem when switching between GUI and CLI mode. Instead we use environment variables to control which groups will be run.
+
+```bash
+CMS_STANDARD_JOURNEY_THREAD_COUNT=1
+CMS_DELETE_LICENCE_JOURNEY_THREAD_COUNT=0
+CMS_DELETE_JOURNEY_THREAD_COUNT=0
+CMS_REBILLING_JOURNEY_THREAD_COUNT=0
+```
+
+> See /environments/.example.env for a full example
+
+Any thread group with a count of 0 _will not be run_.
 
 ## Contributing to this project
 

--- a/cli.sh
+++ b/cli.sh
@@ -9,7 +9,7 @@
 
 dotenv=""
 
-# Unlike run.sh we DO set a default file. We can't create new tests in CLI mode so there is no point in starting up
+# Unlike gui.sh we DO set a default file. We can't create new tests in CLI mode so there is no point in starting up
 # JMeter with just the env vars loaded. tests.jmx currently contains all our tests hence its our default (though we
 # set it in the case statement below).
 testFile=""

--- a/cli.sh
+++ b/cli.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Loading of env vars is based on examples in https://gist.github.com/mihow/9c7f559807069a03e302605691f85572
+#
+# Arg1 is the environment to load config for. Arg2 is the JMeter file to load. Examples of how to load it are
+#
+# $ ./cli.sh dev tests.jmx
+# $ ./cli.sh local
+
+dotenv=""
+
+# Unlike run.sh we DO set a default file. We can't create new tests in CLI mode so there is no point in starting up
+# JMeter with just the env vars loaded. tests.jmx currently contains all our tests hence its our default (though we
+# set it in the case statement below).
+testFile=""
+testName=""
+
+# $# is a special variable which gives the number of arguments passed in. $1 and $2 are special variables to access the
+# first 2 args (goes up to $9). With this case statement we are saying
+#
+# - if only one arg is provided we assume its the env file to use
+# - if 2 args are provided we assume the first is the env file and the second is the jmx file to load
+case $# in
+  1)
+    dotenv="./environments/.$1.env"
+    testFile="tests.jmx"
+    ;;
+  2)
+    dotenv="./environments/.$1.env"
+    testFile="$2"
+    ;;
+  *)
+    # Raise an error to the user
+    echo "ERROR! You must at least specify the environment as an arg"
+    exit 1
+    ;;
+esac
+
+if [ -f $dotenv ]; then
+  # Load Environment Variables
+  export $(cat $dotenv | grep -v '^#' | awk '/=/ {print $1}')
+  echo "Testing against $CMS_BASE_URL"
+  # Extract the suffix from the test file name and drop the .jmx extension. We can then use this to specify exactly
+  # which JMeter output file to both delete (from a previous run) and create
+  testName=$(basename -s .jmx $testFile)
+  # Delete the existing JMeter output file (-f means if it doesn't we won't throw an error)
+  rm -f "$testName.jtl"
+  sh $CMS_JMETER_PATH -t $testFile -n -l tests.jtl
+fi

--- a/environments/.example.env
+++ b/environments/.example.env
@@ -1,5 +1,5 @@
 # JMeter details
-# Needs to be the full path for run.sh to be able to use it
+# Needs to be the full path for gui.sh to be able to use it
 CMS_JMETER_PATH=/Users/janedoe/jmeter/bin/jmeter.sh
 
 # Cognito details

--- a/environments/.example.env
+++ b/environments/.example.env
@@ -19,3 +19,9 @@ CMS_PORT=3003
 CMS_TEST_COUNT=5
 # How many transactions to create within a test (most tests are based on creating a bill run with x transactions)
 CMS_TRANSACTION_COUNT=100
+
+# Use these to control which tests (thread groups) get run when using the CLI
+CMS_STANDARD_JOURNEY_THREAD_COUNT=1
+CMS_DELETE_LICENCE_JOURNEY_THREAD_COUNT=0
+CMS_DELETE_JOURNEY_THREAD_COUNT=0
+CMS_REBILLING_JOURNEY_THREAD_COUNT=0

--- a/gui.sh
+++ b/gui.sh
@@ -4,8 +4,8 @@
 #
 # Arg1 is the environment to load config for. Arg2 is the JMeter file to load. Examples of how to load it are
 #
-# $ ./run.sh dev tests.jmx
-# $ ./run.sh local
+# $ ./gui.sh dev tests.jmx
+# $ ./gui.sh local
 
 dotenv=""
 

--- a/tests.jmx
+++ b/tests.jmx
@@ -18,7 +18,7 @@
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.num_threads">0</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -127,13 +127,13 @@ without actual network activity. This helps debugging tests.</stringProp>
         </DebugSampler>
         <hashTree/>
       </hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Standard journey" enabled="false">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Standard journey" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${threadCount}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -192,6 +192,11 @@ without actual network activity. This helps debugging tests.</stringProp>
             <elementProp name="testCount" elementType="Argument">
               <stringProp name="Argument.name">testCount</stringProp>
               <stringProp name="Argument.value">${__env(CMS_TEST_COUNT)}</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="threadCount" elementType="Argument">
+              <stringProp name="Argument.name">threadCount</stringProp>
+              <stringProp name="Argument.value">${__env(CMS_STANDARD_JOURNEY_THREAD_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
           </collectionProp>
@@ -588,7 +593,7 @@ without actual network activity. This helps debugging tests.</stringProp>
             <hashTree/>
           </hashTree>
         </hashTree>
-        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -625,7 +630,7 @@ without actual network activity. This helps debugging tests.</stringProp>
           <stringProp name="filename"></stringProp>
         </ResultCollector>
         <hashTree/>
-        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="false">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -660,7 +665,7 @@ without actual network activity. This helps debugging tests.</stringProp>
           <stringProp name="filename"></stringProp>
         </ResultCollector>
         <hashTree/>
-        <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="true">
+        <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="false">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -699,7 +704,7 @@ without actual network activity. This helps debugging tests.</stringProp>
           <stringProp name="RespTimeGraph.interval">1000</stringProp>
         </ResultCollector>
         <hashTree/>
-        <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="true">
+        <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="false">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -736,20 +741,20 @@ without actual network activity. This helps debugging tests.</stringProp>
           <stringProp name="filename"></stringProp>
         </ResultCollector>
         <hashTree/>
-        <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="true">
+        <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="false">
           <boolProp name="displayJMeterProperties">false</boolProp>
           <boolProp name="displayJMeterVariables">true</boolProp>
           <boolProp name="displaySystemProperties">false</boolProp>
         </DebugSampler>
         <hashTree/>
       </hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Delete licence journey" enabled="true">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Delete licence journey" enabled="false">
         <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${threadCount}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -808,6 +813,11 @@ without actual network activity. This helps debugging tests.</stringProp>
             <elementProp name="testCount" elementType="Argument">
               <stringProp name="Argument.name">testCount</stringProp>
               <stringProp name="Argument.value">${__env(CMS_TEST_COUNT)}</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="threadCount" elementType="Argument">
+              <stringProp name="Argument.name">threadCount</stringProp>
+              <stringProp name="Argument.value">${__env(CMS_DELETE_LICENCE_JOURNEY_THREAD_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
           </collectionProp>
@@ -1267,7 +1277,7 @@ without actual network activity. This helps debugging tests.</stringProp>
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${threadCount}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -1326,6 +1336,11 @@ without actual network activity. This helps debugging tests.</stringProp>
             <elementProp name="testCount" elementType="Argument">
               <stringProp name="Argument.name">testCount</stringProp>
               <stringProp name="Argument.value">${__env(CMS_TEST_COUNT)}</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="threadCount" elementType="Argument">
+              <stringProp name="Argument.name">threadCount</stringProp>
+              <stringProp name="Argument.value">${__env(CMS_DELETE_JOURNEY_THREAD_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
           </collectionProp>
@@ -1872,7 +1887,7 @@ without actual network activity. This helps debugging tests.</stringProp>
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">${testCount}</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${threadCount}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -1931,6 +1946,11 @@ without actual network activity. This helps debugging tests.</stringProp>
             <elementProp name="testCount" elementType="Argument">
               <stringProp name="Argument.name">testCount</stringProp>
               <stringProp name="Argument.value">${__env(CMS_TEST_COUNT)}</stringProp>
+              <stringProp name="Argument.metadata">=</stringProp>
+            </elementProp>
+            <elementProp name="threadCount" elementType="Argument">
+              <stringProp name="Argument.name">threadCount</stringProp>
+              <stringProp name="Argument.value">${__env(CMS_REBILLING_JOURNEY_THREAD_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
           </collectionProp>

--- a/tests.jmx
+++ b/tests.jmx
@@ -133,7 +133,7 @@ without actual network activity. This helps debugging tests.</stringProp>
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${threadCount}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${standardThreadCount}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -194,8 +194,8 @@ without actual network activity. This helps debugging tests.</stringProp>
               <stringProp name="Argument.value">${__env(CMS_TEST_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
-            <elementProp name="threadCount" elementType="Argument">
-              <stringProp name="Argument.name">threadCount</stringProp>
+            <elementProp name="standardThreadCount" elementType="Argument">
+              <stringProp name="Argument.name">standardThreadCount</stringProp>
               <stringProp name="Argument.value">${__env(CMS_STANDARD_JOURNEY_THREAD_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
@@ -593,7 +593,7 @@ without actual network activity. This helps debugging tests.</stringProp>
             <hashTree/>
           </hashTree>
         </hashTree>
-        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -630,7 +630,7 @@ without actual network activity. This helps debugging tests.</stringProp>
           <stringProp name="filename"></stringProp>
         </ResultCollector>
         <hashTree/>
-        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="false">
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -665,7 +665,7 @@ without actual network activity. This helps debugging tests.</stringProp>
           <stringProp name="filename"></stringProp>
         </ResultCollector>
         <hashTree/>
-        <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="false">
+        <ResultCollector guiclass="RespTimeGraphVisualizer" testclass="ResultCollector" testname="Response Time Graph" enabled="true">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -704,7 +704,7 @@ without actual network activity. This helps debugging tests.</stringProp>
           <stringProp name="RespTimeGraph.interval">1000</stringProp>
         </ResultCollector>
         <hashTree/>
-        <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="false">
+        <ResultCollector guiclass="TableVisualizer" testclass="ResultCollector" testname="View Results in Table" enabled="true">
           <boolProp name="ResultCollector.error_logging">false</boolProp>
           <objProp>
             <name>saveConfig</name>
@@ -741,20 +741,20 @@ without actual network activity. This helps debugging tests.</stringProp>
           <stringProp name="filename"></stringProp>
         </ResultCollector>
         <hashTree/>
-        <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="false">
+        <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="true">
           <boolProp name="displayJMeterProperties">false</boolProp>
           <boolProp name="displayJMeterVariables">true</boolProp>
           <boolProp name="displaySystemProperties">false</boolProp>
         </DebugSampler>
         <hashTree/>
       </hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Delete licence journey" enabled="false">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Delete licence journey" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${threadCount}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${deleteLicenceThreadCount}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -815,8 +815,8 @@ without actual network activity. This helps debugging tests.</stringProp>
               <stringProp name="Argument.value">${__env(CMS_TEST_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
-            <elementProp name="threadCount" elementType="Argument">
-              <stringProp name="Argument.name">threadCount</stringProp>
+            <elementProp name="deleteLicenceThreadCount" elementType="Argument">
+              <stringProp name="Argument.name">deleteLicenceThreadCount</stringProp>
               <stringProp name="Argument.value">${__env(CMS_DELETE_LICENCE_JOURNEY_THREAD_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
@@ -1271,13 +1271,13 @@ without actual network activity. This helps debugging tests.</stringProp>
         </DebugSampler>
         <hashTree/>
       </hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Delete journey" enabled="false">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Delete journey" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${threadCount}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${deleteThreadCount}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -1338,8 +1338,8 @@ without actual network activity. This helps debugging tests.</stringProp>
               <stringProp name="Argument.value">${__env(CMS_TEST_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
-            <elementProp name="threadCount" elementType="Argument">
-              <stringProp name="Argument.name">threadCount</stringProp>
+            <elementProp name="deleteThreadCount" elementType="Argument">
+              <stringProp name="Argument.name">deleteThreadCount</stringProp>
               <stringProp name="Argument.value">${__env(CMS_DELETE_JOURNEY_THREAD_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
@@ -1881,13 +1881,13 @@ without actual network activity. This helps debugging tests.</stringProp>
         </DebugSampler>
         <hashTree/>
       </hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Rebilling journey" enabled="false">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Rebilling journey" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">stoptest</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">${testCount}</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">${threadCount}</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${rebillingThreadCount}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
@@ -1948,8 +1948,8 @@ without actual network activity. This helps debugging tests.</stringProp>
               <stringProp name="Argument.value">${__env(CMS_TEST_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
-            <elementProp name="threadCount" elementType="Argument">
-              <stringProp name="Argument.name">threadCount</stringProp>
+            <elementProp name="rebillingThreadCount" elementType="Argument">
+              <stringProp name="Argument.name">rebillingThreadCount</stringProp>
               <stringProp name="Argument.value">${__env(CMS_REBILLING_JOURNEY_THREAD_COUNT)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>


### PR DESCRIPTION
Whenever we start JMeter we get this message

```
================================================================================
Don't use GUI mode for load testing !, only for Test creation and Test debugging.
For load testing, use CLI Mode (was NON GUI):
   jmeter -n -t [jmx file] -l [results file] -e -o [Path to web report folder]
& increase Java Heap to meet your test requirements:
   Modify current env variable HEAP="-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m" in the jmeter batch file
Check : https://jmeter.apache.org/usermanual/best-practices.html
================================================================================
```

The problem is we don't want to split out our JMX file as we often find we need to copy something from one Thread Group to another (we know there are ways of breaking up JMeter tests but there is only so much time in the day!)

Launching JMeter in GUI mode means we can easily control which Thread Group will get run by disabling/enabling where necessary. But we have a desire to also add Docker support to the project with an eye on building the tests into our CI and for that, we'll need to use the command line.

There isn't a way to specify a specific thread group via the command line. But we can take advantage of a common method which is to set the `Number of Threads (users)` to 0 for those we don't want to run and 1 or greater for those we do. To do this we'll need to add a new env var for each group (test). We also add an alternate to `run.sh` which will run using the CLI.

We can then take advantage of this locally (and shut JMeter up 😀). But it will also help us when we come to dockerise the project.